### PR TITLE
[codex] Implement Horror Bark recovery plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  laravel:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: application
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, dom, fileinfo, pdo_sqlite
+          coverage: none
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: application/package-lock.json
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Prepare environment
+        run: |
+          cp .env.example .env
+          touch database/database.sqlite
+          php artisan key:generate
+
+      - name: Run PHPUnit
+        run: php artisan test
+
+      - name: Run Pint
+        run: >
+          ./vendor/bin/pint --test
+          app/Filament/Ferry/Resources/FerryBookingResource.php
+          app/Filament/Ferry/Resources/FerryResource.php
+          app/Filament/Ferry/Widgets/FerryQuickActionsWidget.php
+          app/Filament/Game/Resources/GameBookingResource.php
+          app/Filament/Game/Resources/GameResource.php
+          app/Filament/Ride/Resources/RideBookingResource.php
+          app/Filament/Resources/PromotionResource.php
+          app/Filament/Resources/PromotionResource/Pages/ListPromotions.php
+          app/Filament/Resources/PromotionResource/Pages/CreatePromotion.php
+          app/Filament/Resources/PromotionResource/Pages/EditPromotion.php
+          app/Http/Controllers/Bookings/CustomerBookingController.php
+          app/Http/Controllers/Bookings/FerryBookingController.php
+          app/Http/Controllers/FerryOperatorReportController.php
+          app/Http/Controllers/FerryPassController.php
+          app/Http/Controllers/HomeController.php
+          app/Models/FerryBooking.php
+          app/Models/Promotion.php
+          app/Services/FerryPassService.php
+          database/migrations/2026_03_31_000001_create_promotions_table.php
+          database/migrations/2026_03_31_000002_add_pass_fields_to_ferry_bookings_table.php
+          database/seeders/HotelsTableSeeder.php
+          routes/web.php
+          tests/Feature/ExampleTest.php
+          tests/Feature/OperatorPanelScopingTest.php
+          tests/Feature/PromotionsAndFerryOperationsTest.php
+
+      - name: Build frontend assets
+        run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,106 +1,50 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for code agents working in this repository.
 
 ## Project Overview
+Horror Bark is a Laravel 11 resort/theme park booking platform with Filament 3 panels. The main application lives in `application/`. Public flows cover hotels, ferries, rides, games, beach events, invoices, ferry passes, promotions, and the customer portal.
 
-Horror-Bark is a Laravel 11 theme park and island resort booking platform with Filament 3 admin panels. The main application lives in `application/`. It powers a multi-type booking system for hotels, ferry tickets, theme park rides, games, and beach events.
-
-## Common Commands
-
-All commands run from `application/`:
+## Commands
+Run from `application/`:
 
 ```bash
-# Development (runs server + queue + logs + Vite concurrently)
 composer dev
-
-# Individual commands
-php artisan serve              # Laravel dev server
-npm run dev                    # Vite dev server
-npm run build                  # Build assets for production
-
-# Database
-php artisan migrate:fresh --seed   # Reset and seed database
-
-# Testing and code quality
-php artisan test               # Run PHPUnit tests
-php artisan pint               # Format PHP code with Laravel Pint
+php artisan test
+./vendor/bin/pint --test
+npm run build
+php artisan migrate:fresh --seed
 ```
 
-## Architecture
-
-### Multi-Panel Admin System
-
-Six Filament admin panels with role-based access:
-
-| Path | Panel | Purpose |
-|------|-------|---------|
-| `/admin` | Admin | Full access, all resources |
-| `/hotel` | Hotel | Hotel operators manage rooms and hotel bookings |
-| `/ferry` | Ferry | Ferry operators manage ferries and ferry bookings |
-| `/ride` | Ride | Ride operators manage rides and ride bookings |
-| `/game` | Game | Game operators manage games and game bookings |
-| `/user` | User | Customer portal |
-
-Each panel auto-discovers resources from its namespace (e.g., `App\Filament\Hotel\Resources`). Operator panels scope queries via `getEloquentQuery()` to show only the authenticated user's entities.
-
-### Owner/Operator Pattern
-
-Ferries, Rides, Games, and BeachEvents have a `user_id` referencing the operator/owner:
-```php
-public function owner() { return $this->belongsTo(User::class, 'user_id'); }
-```
-
-### Booking System
-
-Five booking types share common fields: `user_id`, `quantity`, `total_price`, `status` (pending/confirmed/canceled).
-
-**Time slot rules:**
-- **Hotel**: Date range (`start_date`, `end_date`), capacity = room's `max_occupancy`
-- **Ferry**: Hourly slots 9:00-16:00, capacity per slot = `max_capacity`
-- **Ride/Game**: Only 9:00 or 17:00 slots, capacity per slot = `max_capacity`
-- **Beach Event**: Must match event's `event_date`, capacity = `max_capacity`
-
-### Invoice System
-
-All bookings auto-generate polymorphic invoices with PDF (via DomPDF):
-```php
-$invoiceService->createForBooking($booking, $userId, (float) $booking->total_price);
-```
-PDFs stored in `storage/app/invoices/`. Invoice number format: `INV-YYYYMMDD-XXXXXX`.
-
-### Authorization
-
-Each booking type has a policy (e.g., `HotelBookingPolicy`) checking `$booking->user_id === auth()->id()`.
-
-## Key Paths
-
-- Filament resources: `application/app/Filament/` (organized by panel)
-- Booking controllers: `application/app/Http/Controllers/Bookings/`
-- Models: `application/app/Models/`
-- Routes: `application/routes/web.php`
-- Views: `application/resources/views/`
-- Migrations: `application/database/migrations/`
+## Architecture Notes
+- Multi-panel Filament setup: `admin`, `hotel`, `ferry`, `ride`, `game`, `user`
+- Operator resources are ownership-scoped inside their respective panels
+- Ferry bookings generate invoices and ferry passes
+- Promotions are admin-managed and surfaced on the homepage
+- Ferry passenger reports are available at `/ferry/passenger-reports`
+- Island-aware validation is centralized in `App\Services\IslandAccessService`
 
 ## Tech Stack
+- Laravel 11.31
+- Filament 3.3
+- Blade + Tailwind + Alpine + Vite
+- Spatie Permission + Filament Shield
+- DomPDF
+- Leaflet / map integrations for island and attraction mapping
 
-- Laravel 11.31 with Filament 3.3
-- Blade + Tailwind CSS + Alpine.js
-- Vite for asset bundling
-- Spatie Laravel Permission + FilamentShield
-- barryvdh/laravel-dompdf for PDF invoices
-- Dotswan MapPicker (admin) + Laravel Maps Suite with Leaflet (frontend)
-- Currency: MVR (Maldivian Rufiyaa)
+## Key Paths
+- `application/app/Filament/`
+- `application/app/Http/Controllers/`
+- `application/app/Services/`
+- `application/app/Models/`
+- `application/resources/views/`
+- `application/database/migrations/`
+- `application/tests/`
 
-## Environment
+## Seeded Admin
+- Email: `test@admin.com`
+- Password: `test@admin.com`
 
-Default `.env.example` uses SQLite. Docker uses MySQL (`horrorbark` / `db_user` / `db_password`).
-
-Seeded admin: `test@admin.com` / `test@admin.com`
-
-## Reference Documentation
-
-See `.claude/skills/horror-bark-resort/references/` for detailed docs:
-- `database_schema.md` - Complete database structure
-- `booking_workflows.md` - Booking validation logic per type
-- `filament_patterns.md` - Common Filament patterns
+## Status Note
+- `uwe-course.md` is contextual background only.
+- For repo status, prefer the main README and docs in `docs/`.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,34 @@
-# Horror Bark (Laravel 11 + Filament)
+# Horror Bark
 
-Horror Bark is a booking platform for a theme park experience. The app includes customer-facing booking flows (hotel, ferry, rides, games, beach events) and multiple Filament panels for operations.
+Horror Bark is a Laravel 11 + Filament booking platform for a horror-themed island resort and theme park. The public app supports hotel stays, ferry tickets, rides, games, beach events, invoices, ferry passes, CMS pages, promotions, and a customer booking portal. Filament panels handle admin and operator workflows for hotels, ferries, rides, games, and end users.
+
+## Current State
+- Mature academic/demo MVP rather than a starter project.
+- Core customer booking flows are implemented and covered by feature tests.
+- Operator/admin dashboards exist across panels.
+- Island-aware booking rules are enforced in code.
+- Promotions, ferry passes, and ferry passenger reports are now implemented.
+- CI is configured to run PHP tests, Pint, and the frontend production build.
 
 ## App URLs
 - App: `http://127.0.0.1:8000`
-- Admin panel: `http://127.0.0.1:8000/admin`
+- Admin: `http://127.0.0.1:8000/admin`
+- Hotel panel: `http://127.0.0.1:8000/hotel`
+- Ferry panel: `http://127.0.0.1:8000/ferry`
+- Ride panel: `http://127.0.0.1:8000/ride`
+- Game panel: `http://127.0.0.1:8000/game`
+- User panel: `http://127.0.0.1:8000/user`
 
 ## Local Setup
-1. `cd application`
-2. `composer install`
-3. `npm install`
-4. `cp .env.example .env`
-5. Configure DB credentials in `.env`
-6. `php artisan key:generate`
-7. `php artisan migrate:fresh --seed`
-8. `php artisan storage:link`
-9. `composer dev`
+Run from `application/`:
+
+1. `composer install`
+2. `npm install`
+3. `cp .env.example .env`
+4. `php artisan key:generate`
+5. `php artisan migrate:fresh --seed`
+6. `php artisan storage:link`
+7. `composer dev`
 
 ## Docker Setup
 1. `docker-compose up -d`
@@ -27,50 +40,26 @@ Horror Bark is a booking platform for a theme park experience. The app includes 
 7. `php artisan storage:link`
 8. `php artisan vendor:publish --tag=maps-views`
 
-If Docker builds fail unexpectedly:
-- `docker compose build --no-cache`
-
-## Seeded Admin Credentials
+## Seeded Admin
 - Email: `test@admin.com`
 - Password: `test@admin.com`
-- Default seeded role: `super_admin`
+- Role: `super_admin`
 
-## Panel Access (RBAC)
-Panel access is role-based and enforced at panel level.
+## Implemented Highlights
+- Public catalogs for hotels, ferries, rides, games, and beach events
+- Customer registration/login and booking portal
+- Invoice PDF generation and download
+- Ferry pass generation and download
+- Island-aware access rules for Horror Island vs Picnic Island
+- Promotions managed via Filament and rendered on the homepage
+- Ferry passenger/trip reporting with CSV export
+- Multi-panel Filament dashboards and role-based panel access
 
-| Panel ID / Path | Allowed Roles |
-| --- | --- |
-| `admin` (`/admin`) | `admin`, `super_admin` |
-| `hotel` (`/hotel`) | `hotel_manager`, `super_admin` |
-| `ferry` (`/ferry`) | `ferry_manager`, `super_admin` |
-| `ride` (`/ride`) | `ride_manager`, `super_admin` |
-| `game` (`/game`) | `game_manager`, `super_admin` |
-| `user` (`/user`) | `user`, `super_admin` |
-
-### Supported Roles
-- `super_admin`
-- `admin`
-- `hotel_manager`
-- `ferry_manager`
-- `ride_manager`
-- `game_manager`
-- `user`
-
-Notes:
-- `super_admin` can access all panels.
-- `admin` is restricted to `/admin` only.
-- Users are managed as single-role accounts in the admin user form.
-
-## Seed Only Roles + Super Admin Assignment
+## Tests and Checks
 Run from `application/`:
-- `php artisan db:seed --class=RolesAndPanelAccessSeeder`
-
-## Common Commands (run from `application/`)
-- Full dev stack: `composer dev`
-- Vite only: `npm run dev`
-- Build assets: `npm run build`
-- Run tests: `php artisan test`
-- Format PHP: `php artisan pint`
+- `php artisan test`
+- `./vendor/bin/pint --test`
+- `npm run build`
 
 ## Key Paths
 - App code: `application/app/`
@@ -78,7 +67,8 @@ Run from `application/`:
 - Views/assets: `application/resources/`
 - Migrations/seeders: `application/database/`
 - Tests: `application/tests/`
-- Public assets: `application/public/`
-- Nginx config: `nginx/`
-- PHP-FPM config: `php/`
-- Docker compose: `docker-compose.yml`
+- Docker config: `docker-compose.yml`, `nginx/`, `php/`
+
+## Notes
+- `uwe-course.md` is a UWE module specification, not the authoritative feature/status document for this repo.
+- See `docs/` for the current architecture, developer notes, and backlog.

--- a/application/app/Filament/Ferry/Resources/FerryBookingResource.php
+++ b/application/app/Filament/Ferry/Resources/FerryBookingResource.php
@@ -3,8 +3,8 @@
 namespace App\Filament\Ferry\Resources;
 
 use App\Filament\Ferry\Resources\FerryBookingResource\Pages;
+use App\Models\Ferry;
 use App\Models\FerryBooking;
-use Filament\Forms;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -12,6 +12,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class FerryBookingResource extends Resource
 {
@@ -19,16 +20,30 @@ class FerryBookingResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereHas('ferry', fn (Builder $query) => $query->where('user_id', auth()->id()));
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
                 Select::make('user_id')
                     ->relationship('user', 'name')
+                    ->searchable()
+                    ->preload()
                     ->required(),
 
                 Select::make('ferry_id')
-                    ->relationship('ferry', 'name')
+                    ->label('Ferry')
+                    ->options(fn () => Ferry::query()
+                        ->where('user_id', auth()->id())
+                        ->orderBy('name')
+                        ->pluck('name', 'id')
+                        ->toArray())
+                    ->searchable()
                     ->required(),
 
                 DateTimePicker::make('booking_time')

--- a/application/app/Filament/Ferry/Resources/FerryResource.php
+++ b/application/app/Filament/Ferry/Resources/FerryResource.php
@@ -2,42 +2,45 @@
 
 namespace App\Filament\Ferry\Resources;
 
-
 use App\Filament\Ferry\Resources\FerryResource\Pages;
 use App\Models\Ferry;
-use Filament\Forms;
-use Filament\Forms\Form;
-use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class FerryResource extends Resource
 {
     protected static ?string $model = Ferry::class;
+
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('user_id', auth()->id());
+    }
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
+                Hidden::make('user_id')
+                    ->default(fn () => auth()->id())
+                    ->required(),
+
                 TextInput::make('name')
                     ->required()
                     ->maxLength(255),
-
-                Select::make('user_id')
-                    ->relationship('owner', 'name')
-                    ->required()
-                    ->label('Owner'),
 
                 Select::make('island_id')
                     ->relationship('island', 'name')
                     ->required()
                     ->label('Island'),
-
-
-                    
 
                 TextInput::make('price')
                     ->numeric()
@@ -59,7 +62,6 @@ class FerryResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('name')->sortable(),
-                Tables\Columns\TextColumn::make('owner.name')->label('Owner'),
                 Tables\Columns\TextColumn::make('island.name')->label('Island'),
                 Tables\Columns\TextColumn::make('price')->money('MVR')->sortable(),
                 Tables\Columns\TextColumn::make('max_capacity')->sortable(),
@@ -93,26 +95,4 @@ class FerryResource extends Resource
             'edit' => Pages\EditFerry::route('/{record}/edit'),
         ];
     }
-
-    // ➡️ This is the important part to restrict what each Ferry Operator can see
-    // public static function getEloquentQuery(): Builder
-    // {
-    //     return parent::getEloquentQuery()
-    //         ->where('user_id', Auth::id());
-    // }
-
-    // public static function canEdit($record): bool
-    // {
-    //     return $record->user_id === Auth::id();
-    // }
-
-    // public static function canDelete($record): bool
-    // {
-    //     return $record->user_id === Auth::id();
-    // }
-
-    // public static function canView($record): bool
-    // {
-    //     return $record->user_id === Auth::id();
-    // }
 }

--- a/application/app/Filament/Ferry/Widgets/FerryQuickActionsWidget.php
+++ b/application/app/Filament/Ferry/Widgets/FerryQuickActionsWidget.php
@@ -26,6 +26,12 @@ class FerryQuickActionsWidget extends QuickActionsWidget
                 'icon' => 'heroicon-m-plus',
                 'color' => 'secondary',
             ],
+            [
+                'label' => 'Passenger Reports',
+                'url' => route('ferry-reports.index'),
+                'icon' => 'heroicon-m-document-chart-bar',
+                'color' => 'secondary',
+            ],
         ];
     }
 

--- a/application/app/Filament/Game/Resources/GameBookingResource.php
+++ b/application/app/Filament/Game/Resources/GameBookingResource.php
@@ -10,6 +10,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class GameBookingResource extends Resource
 {
@@ -17,16 +18,28 @@ class GameBookingResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereHas('game', fn (Builder $query) => $query->where('user_id', auth()->id()));
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([
-            // Select the user making the booking
             Forms\Components\Select::make('user_id')
                 ->relationship('user', 'name')
+                ->searchable()
+                ->preload()
                 ->required(),
-            // Select the game; reactive so that changes update total_price
             Forms\Components\Select::make('game_id')
-                ->relationship('game', 'name')
+                ->label('Game')
+                ->options(fn () => Game::query()
+                    ->where('user_id', auth()->id())
+                    ->orderBy('name')
+                    ->pluck('name', 'id')
+                    ->toArray())
+                ->searchable()
                 ->reactive()
                 ->afterStateUpdated(function (callable $get, callable $set) {
                     $gameId = $get('game_id');
@@ -39,10 +52,8 @@ class GameBookingResource extends Resource
                     }
                 })
                 ->required(),
-            // Booking time field
             Forms\Components\DateTimePicker::make('booking_time')
                 ->required(),
-            // Quantity field; reactive so that changes update total_price
             Forms\Components\TextInput::make('quantity')
                 ->numeric()
                 ->minValue(1)
@@ -58,16 +69,14 @@ class GameBookingResource extends Resource
                     }
                 })
                 ->required(),
-            // Calculated total_price field (read-only but dehydrated)
             Forms\Components\TextInput::make('total_price')
                 ->numeric()
                 ->disabled()
                 ->dehydrated(true)
                 ->required(),
-            // Booking status field
             Forms\Components\Select::make('status')
                 ->options([
-                    'pending'   => 'Pending',
+                    'pending' => 'Pending',
                     'confirmed' => 'Confirmed',
                     'canceled' => 'Canceled',
                 ])
@@ -90,9 +99,9 @@ class GameBookingResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index'  => Pages\ListGameBookings::route('/'),
+            'index' => Pages\ListGameBookings::route('/'),
             'create' => Pages\CreateGameBooking::route('/create'),
-            'edit'   => Pages\EditGameBooking::route('/{record}/edit'),
+            'edit' => Pages\EditGameBooking::route('/{record}/edit'),
         ];
     }
 }

--- a/application/app/Filament/Game/Resources/GameResource.php
+++ b/application/app/Filament/Game/Resources/GameResource.php
@@ -7,11 +7,13 @@ use App\Models\Game;
 use App\Services\IslandAccessService;
 use Dotswan\MapPicker\Fields\Map;
 use Filament\Forms;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Form;
 use Filament\Forms\Set;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class GameResource extends Resource
 {
@@ -19,13 +21,17 @@ class GameResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('user_id', auth()->id());
+    }
+
     public static function form(Form $form): Form
     {
         return $form->schema([
-            // Owner of the game
-            Forms\Components\Select::make('user_id')
-                ->label('Owner')
-                ->relationship('owner', 'name')
+            Hidden::make('user_id')
+                ->default(fn () => auth()->id())
                 ->required(),
             Forms\Components\TextInput::make('name')
                 ->required(),
@@ -53,10 +59,10 @@ class GameResource extends Resource
                 ->zoom(16)
                 ->minZoom(0)
                 ->maxZoom(28)
-                ->tilesUrl("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")
+                ->tilesUrl('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}')
                 ->detectRetina(true)
                 ->showMarker(true)
-                ->markerColor("#3b82f6")
+                ->markerColor('#3b82f6')
                 ->showFullscreenControl(true)
                 ->afterStateHydrated(function ($state, $record, Set $set): void {
                     if ($record && $record->latitude && $record->longitude) {
@@ -96,9 +102,6 @@ class GameResource extends Resource
     public static function table(Table $table): Table
     {
         return $table->columns([
-            Tables\Columns\TextColumn::make('owner.name')
-                ->label('Owner')
-                ->sortable(),
             Tables\Columns\TextColumn::make('name')
                 ->sortable(),
             Tables\Columns\TextColumn::make('price')
@@ -127,9 +130,9 @@ class GameResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index'  => Pages\ListGames::route('/'),
+            'index' => Pages\ListGames::route('/'),
             'create' => Pages\CreateGame::route('/create'),
-            'edit'   => Pages\EditGame::route('/{record}/edit'),
+            'edit' => Pages\EditGame::route('/{record}/edit'),
         ];
     }
 }

--- a/application/app/Filament/Resources/PromotionResource.php
+++ b/application/app/Filament/Resources/PromotionResource.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PromotionResource\Pages;
+use App\Models\Promotion;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PromotionResource extends Resource
+{
+    protected static ?string $model = Promotion::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-megaphone';
+
+    protected static ?string $navigationGroup = 'Website Configurations';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->required()
+                    ->maxLength(255),
+
+                Forms\Components\Textarea::make('description')
+                    ->required()
+                    ->rows(4)
+                    ->columnSpanFull(),
+
+                Forms\Components\TextInput::make('discount_percentage')
+                    ->numeric()
+                    ->minValue(0)
+                    ->maxValue(100)
+                    ->suffix('%'),
+
+                Forms\Components\TextInput::make('cta_label')
+                    ->maxLength(255),
+
+                Forms\Components\TextInput::make('cta_url')
+                    ->maxLength(255)
+                    ->helperText('Use an internal path like /hotels or a full URL.'),
+
+                Forms\Components\FileUpload::make('image_path')
+                    ->label('Promotion Image')
+                    ->directory('promotions')
+                    ->image()
+                    ->imageEditor(),
+
+                Forms\Components\DateTimePicker::make('starts_at'),
+
+                Forms\Components\DateTimePicker::make('ends_at')
+                    ->after('starts_at'),
+
+                Forms\Components\Toggle::make('is_active')
+                    ->default(true)
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('discount_percentage')
+                    ->label('Discount')
+                    ->formatStateUsing(fn ($state) => filled($state) ? number_format((float) $state, 2).'%' : 'Content only'),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('starts_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('ends_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPromotions::route('/'),
+            'create' => Pages\CreatePromotion::route('/create'),
+            'edit' => Pages\EditPromotion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/application/app/Filament/Resources/PromotionResource/Pages/CreatePromotion.php
+++ b/application/app/Filament/Resources/PromotionResource/Pages/CreatePromotion.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PromotionResource\Pages;
+
+use App\Filament\Resources\PromotionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePromotion extends CreateRecord
+{
+    protected static string $resource = PromotionResource::class;
+}

--- a/application/app/Filament/Resources/PromotionResource/Pages/EditPromotion.php
+++ b/application/app/Filament/Resources/PromotionResource/Pages/EditPromotion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PromotionResource\Pages;
+
+use App\Filament\Resources\PromotionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPromotion extends EditRecord
+{
+    protected static string $resource = PromotionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/application/app/Filament/Resources/PromotionResource/Pages/ListPromotions.php
+++ b/application/app/Filament/Resources/PromotionResource/Pages/ListPromotions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PromotionResource\Pages;
+
+use App\Filament\Resources\PromotionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPromotions extends ListRecords
+{
+    protected static string $resource = PromotionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/application/app/Filament/Ride/Resources/RideBookingResource.php
+++ b/application/app/Filament/Ride/Resources/RideBookingResource.php
@@ -5,17 +5,15 @@ namespace App\Filament\Ride\Resources;
 use App\Filament\Ride\Resources\RideBookingResource\Pages;
 use App\Models\Ride;
 use App\Models\RideBooking;
-use Filament\Forms;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Filament\Forms\Components\DateTimePicker;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Hidden;
-use Carbon\Carbon;
 
 class RideBookingResource extends Resource
 {
@@ -25,7 +23,8 @@ class RideBookingResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()->where('user_id', auth()->id());
+        return parent::getEloquentQuery()
+            ->whereHas('ride', fn (Builder $query) => $query->where('user_id', auth()->id()));
     }
 
     public static function form(Form $form): Form

--- a/application/app/Http/Controllers/Bookings/CustomerBookingController.php
+++ b/application/app/Http/Controllers/Bookings/CustomerBookingController.php
@@ -29,7 +29,7 @@ class CustomerBookingController extends Controller
         $bookings = collect();
         $selectedType = $filters['type'] ?? null;
 
-        if (!$selectedType || $selectedType === 'hotel') {
+        if (! $selectedType || $selectedType === 'hotel') {
             $bookings = $bookings->merge(
                 $this->buildHotelQuery($user, $filters)->get()->map(
                     fn (HotelBooking $booking) => $this->mapHotelBooking($booking)
@@ -37,7 +37,7 @@ class CustomerBookingController extends Controller
             );
         }
 
-        if (!$selectedType || $selectedType === 'ferry') {
+        if (! $selectedType || $selectedType === 'ferry') {
             $bookings = $bookings->merge(
                 $this->buildFerryQuery($user, $filters)->get()->map(
                     fn (FerryBooking $booking) => $this->mapFerryBooking($booking)
@@ -45,7 +45,7 @@ class CustomerBookingController extends Controller
             );
         }
 
-        if (!$selectedType || $selectedType === 'ride') {
+        if (! $selectedType || $selectedType === 'ride') {
             $bookings = $bookings->merge(
                 $this->buildRideQuery($user, $filters)->get()->map(
                     fn (RideBooking $booking) => $this->mapRideBooking($booking)
@@ -53,7 +53,7 @@ class CustomerBookingController extends Controller
             );
         }
 
-        if (!$selectedType || $selectedType === 'game') {
+        if (! $selectedType || $selectedType === 'game') {
             $bookings = $bookings->merge(
                 $this->buildGameQuery($user, $filters)->get()->map(
                     fn (GameBooking $booking) => $this->mapGameBooking($booking)
@@ -61,7 +61,7 @@ class CustomerBookingController extends Controller
             );
         }
 
-        if (!$selectedType || $selectedType === 'beach-event') {
+        if (! $selectedType || $selectedType === 'beach-event') {
             $bookings = $bookings->merge(
                 $this->buildBeachEventQuery($user, $filters)->get()->map(
                     fn (BeachEventBooking $booking) => $this->mapBeachEventBooking($booking)
@@ -95,12 +95,12 @@ class CustomerBookingController extends Controller
 
         $receiptsQuery = $user->invoices()->latest('issued_at');
 
-        if (!empty($filters['receipt_search'])) {
+        if (! empty($filters['receipt_search'])) {
             $search = trim($filters['receipt_search']);
-            $receiptsQuery->where('invoice_number', 'like', '%' . $search . '%');
+            $receiptsQuery->where('invoice_number', 'like', '%'.$search.'%');
         }
 
-        if (!empty($filters['receipt_status'])) {
+        if (! empty($filters['receipt_status'])) {
             $receiptsQuery->where('status', $filters['receipt_status']);
         }
 
@@ -135,6 +135,7 @@ class CustomerBookingController extends Controller
             'type' => 'Ferry',
             'invoice' => $ferryBooking->invoice,
             'cancelRoute' => route('bookings.ferries.cancel', $ferryBooking),
+            'passDownloadUrl' => route('bookings.ferries.pass', $ferryBooking),
         ]);
     }
 
@@ -147,6 +148,7 @@ class CustomerBookingController extends Controller
             'type' => 'Ride',
             'invoice' => $rideBooking->invoice,
             'cancelRoute' => route('bookings.rides.cancel', $rideBooking),
+            'passDownloadUrl' => null,
         ]);
     }
 
@@ -159,6 +161,7 @@ class CustomerBookingController extends Controller
             'type' => 'Game',
             'invoice' => $gameBooking->invoice,
             'cancelRoute' => route('bookings.games.cancel', $gameBooking),
+            'passDownloadUrl' => null,
         ]);
     }
 
@@ -171,6 +174,7 @@ class CustomerBookingController extends Controller
             'type' => 'Beach Event',
             'invoice' => $beachEventBooking->invoice,
             'cancelRoute' => route('bookings.beach-events.cancel', $beachEventBooking),
+            'passDownloadUrl' => null,
         ]);
     }
 
@@ -248,21 +252,21 @@ class CustomerBookingController extends Controller
     {
         $query = $user->hotelBookings()->with('room.hotel')->latest();
 
-        if (!empty($filters['search'])) {
+        if (! empty($filters['search'])) {
             $query->where(function ($builder) use ($filters) {
                 $builder->whereHas('room.hotel', function ($inner) use ($filters) {
-                    $inner->where('name', 'like', '%' . $filters['search'] . '%');
+                    $inner->where('name', 'like', '%'.$filters['search'].'%');
                 })->orWhereHas('room', function ($inner) use ($filters) {
-                    $inner->where('room_number', 'like', '%' . $filters['search'] . '%');
+                    $inner->where('room_number', 'like', '%'.$filters['search'].'%');
                 });
             });
         }
 
-        if (!empty($filters['from'])) {
+        if (! empty($filters['from'])) {
             $query->whereDate('start_date', '>=', $filters['from']);
         }
 
-        if (!empty($filters['to'])) {
+        if (! empty($filters['to'])) {
             $query->whereDate('start_date', '<=', $filters['to']);
         }
 
@@ -273,17 +277,17 @@ class CustomerBookingController extends Controller
     {
         $query = $user->ferryBookings()->with('ferry')->latest();
 
-        if (!empty($filters['search'])) {
+        if (! empty($filters['search'])) {
             $query->whereHas('ferry', function ($builder) use ($filters) {
-                $builder->where('name', 'like', '%' . $filters['search'] . '%');
+                $builder->where('name', 'like', '%'.$filters['search'].'%');
             });
         }
 
-        if (!empty($filters['from'])) {
+        if (! empty($filters['from'])) {
             $query->whereDate('booking_time', '>=', $filters['from']);
         }
 
-        if (!empty($filters['to'])) {
+        if (! empty($filters['to'])) {
             $query->whereDate('booking_time', '<=', $filters['to']);
         }
 
@@ -294,17 +298,17 @@ class CustomerBookingController extends Controller
     {
         $query = $user->rideBookings()->with('ride')->latest();
 
-        if (!empty($filters['search'])) {
+        if (! empty($filters['search'])) {
             $query->whereHas('ride', function ($builder) use ($filters) {
-                $builder->where('name', 'like', '%' . $filters['search'] . '%');
+                $builder->where('name', 'like', '%'.$filters['search'].'%');
             });
         }
 
-        if (!empty($filters['from'])) {
+        if (! empty($filters['from'])) {
             $query->whereDate('booking_time', '>=', $filters['from']);
         }
 
-        if (!empty($filters['to'])) {
+        if (! empty($filters['to'])) {
             $query->whereDate('booking_time', '<=', $filters['to']);
         }
 
@@ -315,17 +319,17 @@ class CustomerBookingController extends Controller
     {
         $query = $user->gameBookings()->with('game')->latest();
 
-        if (!empty($filters['search'])) {
+        if (! empty($filters['search'])) {
             $query->whereHas('game', function ($builder) use ($filters) {
-                $builder->where('name', 'like', '%' . $filters['search'] . '%');
+                $builder->where('name', 'like', '%'.$filters['search'].'%');
             });
         }
 
-        if (!empty($filters['from'])) {
+        if (! empty($filters['from'])) {
             $query->whereDate('booking_time', '>=', $filters['from']);
         }
 
-        if (!empty($filters['to'])) {
+        if (! empty($filters['to'])) {
             $query->whereDate('booking_time', '<=', $filters['to']);
         }
 
@@ -336,17 +340,17 @@ class CustomerBookingController extends Controller
     {
         $query = $user->beachEventBookings()->with('beachEvent')->latest();
 
-        if (!empty($filters['search'])) {
+        if (! empty($filters['search'])) {
             $query->whereHas('beachEvent', function ($builder) use ($filters) {
-                $builder->where('name', 'like', '%' . $filters['search'] . '%');
+                $builder->where('name', 'like', '%'.$filters['search'].'%');
             });
         }
 
-        if (!empty($filters['from'])) {
+        if (! empty($filters['from'])) {
             $query->whereDate('booking_date', '>=', $filters['from']);
         }
 
-        if (!empty($filters['to'])) {
+        if (! empty($filters['to'])) {
             $query->whereDate('booking_date', '<=', $filters['to']);
         }
 
@@ -363,8 +367,8 @@ class CustomerBookingController extends Controller
             'type_label' => 'Hotel',
             'status' => $booking->status,
             'title' => $booking->room->hotel->name ?? 'Hotel',
-            'subtitle' => 'Room ' . ($booking->room->room_number ?? 'N/A'),
-            'schedule' => Carbon::parse($booking->start_date)->toDateString() . ' → ' . Carbon::parse($booking->end_date)->toDateString(),
+            'subtitle' => 'Room '.($booking->room->room_number ?? 'N/A'),
+            'schedule' => Carbon::parse($booking->start_date)->toDateString().' → '.Carbon::parse($booking->end_date)->toDateString(),
             'quantity' => $booking->quantity,
             'total_price' => (float) $booking->total_price,
             'detail_url' => route('bookings.hotels.show', $booking),
@@ -448,7 +452,7 @@ class CustomerBookingController extends Controller
             'status' => $booking->status,
             'title' => $booking->beachEvent->name ?? 'Beach Event',
             'subtitle' => 'Event ticket',
-            'schedule' => Carbon::parse($booking->booking_date)->toDateString() . ' ' . $sortAt->format('H:i'),
+            'schedule' => Carbon::parse($booking->booking_date)->toDateString().' '.$sortAt->format('H:i'),
             'quantity' => $booking->quantity,
             'total_price' => (float) $booking->total_price,
             'detail_url' => route('bookings.beach-events.show', $booking),

--- a/application/app/Http/Controllers/Bookings/FerryBookingController.php
+++ b/application/app/Http/Controllers/Bookings/FerryBookingController.php
@@ -5,10 +5,11 @@ namespace App\Http\Controllers\Bookings;
 use App\Http\Controllers\Controller;
 use App\Models\Ferry;
 use App\Models\FerryBooking;
-use Carbon\Carbon;
-use Illuminate\Http\Request;
+use App\Services\FerryPassService;
 use App\Services\InvoiceService;
 use App\Services\IslandAccessService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
 
 class FerryBookingController extends Controller
 {
@@ -16,12 +17,12 @@ class FerryBookingController extends Controller
         Request $request,
         Ferry $ferry,
         InvoiceService $invoiceService,
+        FerryPassService $ferryPassService,
         IslandAccessService $islandAccessService
-    )
-    {
+    ) {
         $data = $request->validate([
             'booking_time' => ['required', 'date'],
-            'quantity' => ['required', 'integer', 'min:1', 'max:' . $ferry->max_booking_quantity],
+            'quantity' => ['required', 'integer', 'min:1', 'max:'.$ferry->max_booking_quantity],
         ]);
 
         $bookingTime = Carbon::parse($data['booking_time'])->setSecond(0);
@@ -37,7 +38,7 @@ class FerryBookingController extends Controller
 
         if (
             $islandAccessService->ferryRequiresHotel($ferry)
-            && !$islandAccessService->hasConfirmedHotelStayAt($request->user(), $bookingTime)
+            && ! $islandAccessService->hasConfirmedHotelStayAt($request->user(), $bookingTime)
         ) {
             return back()->withErrors([
                 'booking_time' => IslandAccessService::REQUIRED_STAY_ERROR,
@@ -66,6 +67,7 @@ class FerryBookingController extends Controller
         ]);
 
         $invoiceService->createForBooking($booking, $request->user()->id, (float) $booking->total_price);
+        $ferryPassService->createForBooking($booking);
 
         return back()->with('status', 'Ferry booking created.');
     }

--- a/application/app/Http/Controllers/FerryOperatorReportController.php
+++ b/application/app/Http/Controllers/FerryOperatorReportController.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ferry;
+use App\Models\FerryBooking;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FerryOperatorReportController extends Controller
+{
+    public function index(Request $request)
+    {
+        $this->authorizeOperator($request);
+
+        $filters = $this->validatedFilters($request);
+        $ferries = $this->accessibleFerries($request)->get(['id', 'name', 'island_id']);
+
+        if (! empty($filters['ferry_id']) && ! $ferries->contains('id', (int) $filters['ferry_id'])) {
+            abort(403);
+        }
+
+        $manifest = $this->buildManifestQuery($request, $filters)
+            ->orderBy('booking_time')
+            ->get();
+
+        $tripSummary = $manifest
+            ->groupBy(fn (FerryBooking $booking) => $booking->ferry_id.'|'.$booking->booking_time->format('Y-m-d H:i:s'))
+            ->map(function ($group) {
+                /** @var FerryBooking $first */
+                $first = $group->first();
+
+                return [
+                    'ferry_name' => $first->ferry->name,
+                    'departure_time' => $first->booking_time,
+                    'bookings_count' => $group->count(),
+                    'passenger_count' => $group->sum('quantity'),
+                    'revenue' => $group->sum('total_price'),
+                ];
+            })
+            ->sortBy('departure_time')
+            ->values();
+
+        return view('pages.ferry-reports.index', [
+            'filters' => $filters,
+            'ferries' => $ferries,
+            'tripSummary' => $tripSummary,
+            'manifest' => $manifest,
+        ]);
+    }
+
+    public function export(Request $request): StreamedResponse
+    {
+        $this->authorizeOperator($request);
+
+        $filters = $this->validatedFilters($request);
+        $ferries = $this->accessibleFerries($request)->pluck('id');
+
+        if (! empty($filters['ferry_id']) && ! $ferries->contains((int) $filters['ferry_id'])) {
+            abort(403);
+        }
+
+        $manifest = $this->buildManifestQuery($request, $filters)
+            ->orderBy('booking_time')
+            ->get();
+
+        $filename = 'ferry-passenger-report-'.($filters['date'] ?? now()->toDateString()).'.csv';
+
+        return response()->streamDownload(function () use ($manifest) {
+            $handle = fopen('php://output', 'w');
+
+            fputcsv($handle, [
+                'booking_id',
+                'pass_number',
+                'passenger_name',
+                'passenger_email',
+                'ferry',
+                'departure_time',
+                'quantity',
+                'total_price',
+                'status',
+            ]);
+
+            foreach ($manifest as $booking) {
+                fputcsv($handle, [
+                    $booking->id,
+                    $booking->pass_number,
+                    $booking->user->name,
+                    $booking->user->email,
+                    $booking->ferry->name,
+                    $booking->booking_time->format('Y-m-d H:i'),
+                    $booking->quantity,
+                    number_format((float) $booking->total_price, 2, '.', ''),
+                    $booking->status,
+                ]);
+            }
+
+            fclose($handle);
+        }, $filename, [
+            'Content-Type' => 'text/csv',
+        ]);
+    }
+
+    private function validatedFilters(Request $request): array
+    {
+        $filters = $request->validate([
+            'date' => ['nullable', 'date'],
+            'ferry_id' => ['nullable', 'integer', 'exists:ferries,id'],
+            'hour' => ['nullable', 'integer', 'between:9,16'],
+        ]);
+
+        $filters['date'] = $filters['date'] ?? now()->toDateString();
+
+        return $filters;
+    }
+
+    private function accessibleFerries(Request $request)
+    {
+        $query = Ferry::query()->orderBy('name');
+
+        if (! $request->user()->hasRole('super_admin')) {
+            $query->where('user_id', $request->user()->id);
+        }
+
+        return $query;
+    }
+
+    private function buildManifestQuery(Request $request, array $filters)
+    {
+        $query = FerryBooking::query()
+            ->with(['ferry.island', 'user'])
+            ->whereHas('ferry', function ($builder) use ($request) {
+                if (! $request->user()->hasRole('super_admin')) {
+                    $builder->where('user_id', $request->user()->id);
+                }
+            });
+
+        $query->whereDate('booking_time', $filters['date']);
+
+        if (! empty($filters['ferry_id'])) {
+            $query->where('ferry_id', $filters['ferry_id']);
+        }
+
+        if (! empty($filters['hour'])) {
+            $query->whereHour('booking_time', $filters['hour']);
+        }
+
+        return $query;
+    }
+
+    private function authorizeOperator(Request $request): void
+    {
+        abort_unless(
+            $request->user()->hasAnyRole(['ferry_manager', 'super_admin']),
+            403
+        );
+    }
+}

--- a/application/app/Http/Controllers/FerryPassController.php
+++ b/application/app/Http/Controllers/FerryPassController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\FerryBooking;
+use App\Services\FerryPassService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class FerryPassController extends Controller
+{
+    public function download(Request $request, FerryBooking $ferryBooking, FerryPassService $ferryPassService)
+    {
+        $this->authorize('view', $ferryBooking);
+
+        $path = $ferryBooking->pass_path;
+
+        if (! $path || ! Storage::disk('local')->exists($path)) {
+            $path = $ferryPassService->generatePdf($ferryBooking);
+        }
+
+        return Storage::disk('local')->download($path);
+    }
+}

--- a/application/app/Http/Controllers/HomeController.php
+++ b/application/app/Http/Controllers/HomeController.php
@@ -6,6 +6,7 @@ use App\Models\BeachEvent;
 use App\Models\Game;
 use App\Models\Hotel;
 use App\Models\Island;
+use App\Models\Promotion;
 use App\Models\Ride;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -34,6 +35,13 @@ class HomeController extends Controller
             ->whereNotNull('longitude')
             ->get();
 
+        $promotions = Promotion::query()
+            ->active()
+            ->orderByDesc('starts_at')
+            ->orderByDesc('created_at')
+            ->limit(3)
+            ->get();
+
         $hauntRides = Ride::query()
             ->orderBy('name')
             ->orderBy('id')
@@ -52,7 +60,7 @@ class HomeController extends Controller
 
         $otherHaunts = $this->buildOtherHaunts($hauntRides, $hauntGames, $hauntBeachEvents);
 
-        return view('pages.home', compact('hotels', 'islands', 'rides', 'games', 'beachEvents', 'otherHaunts'));
+        return view('pages.home', compact('hotels', 'islands', 'rides', 'games', 'beachEvents', 'promotions', 'otherHaunts'));
     }
 
     private function buildOtherHaunts(Collection $rides, Collection $games, Collection $beachEvents): Collection
@@ -77,7 +85,7 @@ class HomeController extends Controller
             foreach (array_keys($queues) as $type) {
                 $item = $queues[$type]->get($positions[$type]);
 
-                if (!$item) {
+                if (! $item) {
                     continue;
                 }
 
@@ -90,7 +98,7 @@ class HomeController extends Controller
                 }
             }
 
-            if (!$addedInRound) {
+            if (! $addedInRound) {
                 break;
             }
         }
@@ -119,14 +127,14 @@ class HomeController extends Controller
         };
 
         $images = is_array($item->images) ? $item->images : [];
-        $fallbackSeed = Str::slug($type . '-' . $item->id);
+        $fallbackSeed = Str::slug($type.'-'.$item->id);
 
         return [
             'type' => $type,
             'title' => $item->name,
             'description' => filled($item->description ?? null) ? $item->description : $defaultDescription,
             'images' => $images,
-            'image' => empty($images) ? 'https://picsum.photos/seed/' . $fallbackSeed . '/800/1000' : null,
+            'image' => empty($images) ? 'https://picsum.photos/seed/'.$fallbackSeed.'/800/1000' : null,
             'href' => $href,
             'linkText' => $linkText,
         ];

--- a/application/app/Models/FerryBooking.php
+++ b/application/app/Models/FerryBooking.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
-use Carbon\Carbon;
 
 class FerryBooking extends Model
 {
@@ -16,14 +15,20 @@ class FerryBooking extends Model
         'quantity',
         'total_price',
         'status',
+        'pass_number',
+        'pass_path',
     ];
 
-    public function user(): BelongsTo 
+    protected $casts = [
+        'booking_time' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
-    public function ferry(): BelongsTo 
+    public function ferry(): BelongsTo
     {
         return $this->belongsTo(Ferry::class);
     }
@@ -33,9 +38,8 @@ class FerryBooking extends Model
         return $this->morphOne(Invoice::class, 'invoiceable');
     }
 
-    public function isPending(): bool 
+    public function isPending(): bool
     {
         return $this->status === 'pending';
     }
-
 }

--- a/application/app/Models/Promotion.php
+++ b/application/app/Models/Promotion.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+class Promotion extends Model
+{
+    protected $fillable = [
+        'title',
+        'description',
+        'discount_percentage',
+        'cta_label',
+        'cta_url',
+        'image_path',
+        'starts_at',
+        'ends_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'discount_percentage' => 'decimal:2',
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    public function scopeActive(Builder $query, ?Carbon $at = null): Builder
+    {
+        $at ??= now();
+
+        return $query
+            ->where('is_active', true)
+            ->where(function (Builder $builder) use ($at) {
+                $builder->whereNull('starts_at')
+                    ->orWhere('starts_at', '<=', $at);
+            })
+            ->where(function (Builder $builder) use ($at) {
+                $builder->whereNull('ends_at')
+                    ->orWhere('ends_at', '>=', $at);
+            });
+    }
+
+    public function getResolvedCtaLabelAttribute(): string
+    {
+        return $this->cta_label ?: 'View Offer';
+    }
+}

--- a/application/app/Services/FerryPassService.php
+++ b/application/app/Services/FerryPassService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FerryBooking;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class FerryPassService
+{
+    public function createForBooking(FerryBooking $booking): FerryBooking
+    {
+        if (! $booking->pass_number) {
+            $booking->update([
+                'pass_number' => $this->generatePassNumber(),
+            ]);
+        }
+
+        $this->generatePdf($booking);
+
+        return $booking->fresh(['ferry.island', 'user']);
+    }
+
+    public function generatePdf(FerryBooking $booking): string
+    {
+        if (! $booking->pass_number) {
+            $booking->update([
+                'pass_number' => $this->generatePassNumber(),
+            ]);
+        }
+
+        Storage::disk('local')->makeDirectory('ferry-passes');
+
+        $booking->loadMissing('ferry.island', 'user');
+
+        $pdf = app('dompdf.wrapper')->loadView('ferry-passes.pdf', [
+            'booking' => $booking,
+        ]);
+
+        $fileName = 'ferry-passes/'.$booking->pass_number.'.pdf';
+        Storage::disk('local')->put($fileName, $pdf->output());
+
+        $booking->update([
+            'pass_path' => $fileName,
+        ]);
+
+        return $fileName;
+    }
+
+    private function generatePassNumber(): string
+    {
+        return 'PASS-'.now()->format('Ymd').'-'.Str::upper(Str::random(6));
+    }
+}

--- a/application/database/migrations/2026_03_31_000001_create_promotions_table.php
+++ b/application/database/migrations/2026_03_31_000001_create_promotions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('promotions', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description');
+            $table->decimal('discount_percentage', 5, 2)->nullable();
+            $table->string('cta_label')->nullable();
+            $table->string('cta_url')->nullable();
+            $table->string('image_path')->nullable();
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('promotions');
+    }
+};

--- a/application/database/migrations/2026_03_31_000002_add_pass_fields_to_ferry_bookings_table.php
+++ b/application/database/migrations/2026_03_31_000002_add_pass_fields_to_ferry_bookings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ferry_bookings', function (Blueprint $table) {
+            $table->string('pass_number')->nullable()->unique()->after('status');
+            $table->string('pass_path')->nullable()->after('pass_number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ferry_bookings', function (Blueprint $table) {
+            $table->dropColumn(['pass_number', 'pass_path']);
+        });
+    }
+};

--- a/application/database/seeders/HotelsTableSeeder.php
+++ b/application/database/seeders/HotelsTableSeeder.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Seeder;
 
 class HotelsTableSeeder extends Seeder
 {
-
     /**
      * Auto generated seed file
      *
@@ -14,22 +13,19 @@ class HotelsTableSeeder extends Seeder
      */
     public function run()
     {
-        
 
         \DB::table('hotels')->delete();
-        
-        \DB::table('hotels')->insert(array (
-            0 => 
-            array (
+
+        \DB::table('hotels')->insert([
+            0 => [
                 'id' => 1,
                 'user_id' => 1,
-                'name' => 'The shining my nigga',
+                'name' => 'The Shining Manor',
                 'location' => 'Main island ',
                 'created_at' => '2025-03-18 12:10:21',
                 'updated_at' => '2025-03-18 12:10:21',
-            ),
-        ));
-        
-        
+            ],
+        ]);
+
     }
 }

--- a/application/phpunit.xml
+++ b/application/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/application/resources/views/ferry-passes/pdf.blade.php
+++ b/application/resources/views/ferry-passes/pdf.blade.php
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Ferry Pass {{ $booking->pass_number }}</title>
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; color: #111827; margin: 32px; }
+        .ticket { border: 2px solid #111827; border-radius: 16px; padding: 24px; }
+        .heading { font-size: 28px; margin: 0 0 8px; }
+        .subheading { color: #4b5563; margin: 0 0 24px; }
+        .grid { width: 100%; border-collapse: collapse; margin-top: 16px; }
+        .grid td { padding: 10px 0; border-bottom: 1px solid #d1d5db; }
+        .label { font-weight: bold; width: 180px; }
+        .footer { margin-top: 24px; font-size: 12px; color: #6b7280; }
+    </style>
+</head>
+<body>
+    <section class="ticket">
+        <h1 class="heading">Horror Bark Ferry Pass</h1>
+        <p class="subheading">Boarding document for island transfer access</p>
+
+        <table class="grid">
+            <tr>
+                <td class="label">Pass Number</td>
+                <td>{{ $booking->pass_number }}</td>
+            </tr>
+            <tr>
+                <td class="label">Passenger</td>
+                <td>{{ $booking->user->name }} ({{ $booking->user->email }})</td>
+            </tr>
+            <tr>
+                <td class="label">Ferry</td>
+                <td>{{ $booking->ferry->name }}</td>
+            </tr>
+            <tr>
+                <td class="label">Destination</td>
+                <td>{{ $booking->ferry->island?->name ?? 'Island transfer' }}</td>
+            </tr>
+            <tr>
+                <td class="label">Departure</td>
+                <td>{{ $booking->booking_time->format('Y-m-d H:i') }}</td>
+            </tr>
+            <tr>
+                <td class="label">Passengers</td>
+                <td>{{ $booking->quantity }}</td>
+            </tr>
+            <tr>
+                <td class="label">Status</td>
+                <td>{{ ucfirst($booking->status) }}</td>
+            </tr>
+        </table>
+
+        <p class="footer">Present this pass with a matching booking and identification at the ferry checkpoint.</p>
+    </section>
+</body>
+</html>

--- a/application/resources/views/pages/bookings/show.blade.php
+++ b/application/resources/views/pages/bookings/show.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $passDownloadUrl = $passDownloadUrl ?? null;
+@endphp
+
 @section('title', 'Booking Details - Horror-Bark')
 
 @section('content')
@@ -23,6 +27,14 @@
             :status="$invoice->status"
             :download-href="route('invoices.download', $invoice)"
         />
+    @endif
+
+    @if (!empty($passDownloadUrl))
+        <x-ui.surface class="space-y-3">
+            <h2 class="text-xl font-semibold">Ferry Pass</h2>
+            <p class="text-gray-300">Download the issued ferry pass for boarding and manifest checks.</p>
+            <x-ui.button :href="$passDownloadUrl" variant="secondary">Download ferry pass</x-ui.button>
+        </x-ui.surface>
     @endif
 
     @if ($booking->status !== 'canceled')

--- a/application/resources/views/pages/ferry-reports/index.blade.php
+++ b/application/resources/views/pages/ferry-reports/index.blade.php
@@ -1,0 +1,103 @@
+@extends('layouts.app')
+
+@section('title', 'Ferry Passenger Reports - Horror-Bark')
+
+@section('content')
+<main class="space-y-8">
+    <x-ui.section-heading title="Ferry Passenger Reports" size="xl" />
+
+    <x-ui.alert-stack />
+
+    <x-filters.panel
+        :fields="[
+            ['label' => 'Date', 'name' => 'date', 'type' => 'date', 'value' => $filters['date'] ?? now()->toDateString()],
+            ['label' => 'Ferry', 'name' => 'ferry_id', 'type' => 'select', 'options' => collect($ferries)->map(fn($ferry) => ['label' => $ferry->name, 'value' => $ferry->id])->prepend(['label' => 'All ferries', 'value' => ''])->values()->all(), 'value' => $filters['ferry_id'] ?? ''],
+            ['label' => 'Departure Hour', 'name' => 'hour', 'type' => 'select', 'options' => collect(range(9, 16))->map(fn($hour) => ['label' => sprintf('%02d:00', $hour), 'value' => $hour])->prepend(['label' => 'All departures', 'value' => ''])->values()->all(), 'value' => $filters['hour'] ?? ''],
+        ]"
+        :reset-href="route('ferry-reports.index')"
+        apply-label="Run report"
+        grid="grid grid-cols-1 md:grid-cols-3 gap-4"
+    />
+
+    <div class="flex justify-end">
+        <x-ui.button :href="route('ferry-reports.export', array_filter([
+            'date' => $filters['date'] ?? null,
+            'ferry_id' => $filters['ferry_id'] ?? null,
+            'hour' => $filters['hour'] ?? null,
+        ], fn ($value) => !is_null($value) && $value !== ''))" variant="secondary">
+            Export CSV
+        </x-ui.button>
+    </div>
+
+    <x-ui.surface class="space-y-4">
+        <h2 class="text-xl font-semibold">Trip Summary</h2>
+
+        @if ($tripSummary->isEmpty())
+            <p class="text-gray-300">No ferry trips matched the selected filters.</p>
+        @else
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm text-left text-gray-200">
+                    <thead class="text-xs uppercase tracking-wide text-primary-light">
+                        <tr>
+                            <th class="px-3 py-2">Ferry</th>
+                            <th class="px-3 py-2">Departure</th>
+                            <th class="px-3 py-2">Bookings</th>
+                            <th class="px-3 py-2">Passengers</th>
+                            <th class="px-3 py-2">Revenue</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($tripSummary as $trip)
+                            <tr class="border-t border-primary-light/10">
+                                <td class="px-3 py-2">{{ $trip['ferry_name'] }}</td>
+                                <td class="px-3 py-2">{{ $trip['departure_time']->format('Y-m-d H:i') }}</td>
+                                <td class="px-3 py-2">{{ $trip['bookings_count'] }}</td>
+                                <td class="px-3 py-2">{{ $trip['passenger_count'] }}</td>
+                                <td class="px-3 py-2">MVR {{ number_format($trip['revenue'], 2) }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </x-ui.surface>
+
+    <x-ui.surface class="space-y-4">
+        <h2 class="text-xl font-semibold">Passenger Manifest</h2>
+
+        @if ($manifest->isEmpty())
+            <p class="text-gray-300">No passengers found for the selected report.</p>
+        @else
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm text-left text-gray-200">
+                    <thead class="text-xs uppercase tracking-wide text-primary-light">
+                        <tr>
+                            <th class="px-3 py-2">Pass</th>
+                            <th class="px-3 py-2">Passenger</th>
+                            <th class="px-3 py-2">Ferry</th>
+                            <th class="px-3 py-2">Departure</th>
+                            <th class="px-3 py-2">Qty</th>
+                            <th class="px-3 py-2">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($manifest as $booking)
+                            <tr class="border-t border-primary-light/10">
+                                <td class="px-3 py-2">{{ $booking->pass_number ?? 'Pending issue' }}</td>
+                                <td class="px-3 py-2">
+                                    <div>{{ $booking->user->name }}</div>
+                                    <div class="text-xs text-gray-400">{{ $booking->user->email }}</div>
+                                </td>
+                                <td class="px-3 py-2">{{ $booking->ferry->name }}</td>
+                                <td class="px-3 py-2">{{ $booking->booking_time->format('Y-m-d H:i') }}</td>
+                                <td class="px-3 py-2">{{ $booking->quantity }}</td>
+                                <td class="px-3 py-2">{{ ucfirst($booking->status) }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </x-ui.surface>
+</main>
+@endsection

--- a/application/resources/views/pages/home.blade.php
+++ b/application/resources/views/pages/home.blade.php
@@ -30,6 +30,28 @@
         <span class="material-symbols-outlined divider-icon">church</span>
     </div>
 
+    @if ($promotions->isNotEmpty())
+        <section class="space-y-6">
+            <x-ui.section-heading title="Promotions Under The Pale Moon" size="lg" />
+
+            <x-home.featured-grid>
+                @foreach ($promotions as $promotion)
+                    <x-featured-card
+                        :title="filled($promotion->discount_percentage) ? $promotion->title . ' · ' . number_format((float) $promotion->discount_percentage, 0) . '% Off' : $promotion->title"
+                        :description="$promotion->description"
+                        :images="array_filter([$promotion->image_path])"
+                        :link="$promotion->cta_url"
+                        :link-text="$promotion->resolved_cta_label"
+                    />
+                @endforeach
+            </x-home.featured-grid>
+        </section>
+
+        <div class="divider-iron px-4 opacity-60">
+            <span class="material-symbols-outlined divider-icon">local_activity</span>
+        </div>
+    @endif
+
     <x-home.featured-grid>
         @if ($featuredHotel)
             <x-featured-card

--- a/application/routes/web.php
+++ b/application/routes/web.php
@@ -1,25 +1,27 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\PagesController;
-use App\Http\Controllers\ContactController;
-use App\Http\Controllers\BeachEventController;
-use App\Http\Controllers\HomeController;
-use App\Http\Controllers\HotelController;
-use App\Http\Controllers\FerryController;
-use App\Http\Controllers\ThemeParkController;
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
-use App\Http\Controllers\Auth\RegisteredUserController;
-use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\NewPasswordController;
-use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\InvoiceController;
-use App\Http\Controllers\Bookings\HotelBookingController;
-use App\Http\Controllers\Bookings\FerryBookingController;
-use App\Http\Controllers\Bookings\RideBookingController;
-use App\Http\Controllers\Bookings\GameBookingController;
+use App\Http\Controllers\Auth\PasswordResetLinkController;
+use App\Http\Controllers\Auth\RegisteredUserController;
+use App\Http\Controllers\BeachEventController;
 use App\Http\Controllers\Bookings\BeachEventBookingController;
 use App\Http\Controllers\Bookings\CustomerBookingController;
+use App\Http\Controllers\Bookings\FerryBookingController;
+use App\Http\Controllers\Bookings\GameBookingController;
+use App\Http\Controllers\Bookings\HotelBookingController;
+use App\Http\Controllers\Bookings\RideBookingController;
+use App\Http\Controllers\ContactController;
+use App\Http\Controllers\FerryController;
+use App\Http\Controllers\FerryOperatorReportController;
+use App\Http\Controllers\FerryPassController;
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\HotelController;
+use App\Http\Controllers\InvoiceController;
+use App\Http\Controllers\PagesController;
+use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ThemeParkController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', [HomeController::class, 'index'])->name('home');
 
@@ -55,6 +57,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/bookings/rides/{rideBooking}', [CustomerBookingController::class, 'showRide'])->name('bookings.rides.show');
     Route::get('/bookings/games/{gameBooking}', [CustomerBookingController::class, 'showGame'])->name('bookings.games.show');
     Route::get('/bookings/beach-events/{beachEventBooking}', [CustomerBookingController::class, 'showBeachEvent'])->name('bookings.beach-events.show');
+    Route::get('/bookings/ferries/{ferryBooking}/pass', [FerryPassController::class, 'download'])->name('bookings.ferries.pass');
 
     Route::post('/bookings/hotels/rooms/{room}', [HotelBookingController::class, 'store'])->name('bookings.hotels.store');
     Route::post('/bookings/ferries/{ferry}', [FerryBookingController::class, 'store'])->name('bookings.ferries.store');
@@ -74,10 +77,11 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/invoices/{invoice}', [InvoiceController::class, 'show'])->name('invoices.show');
     Route::get('/invoices/{invoice}/download', [InvoiceController::class, 'download'])->name('invoices.download');
+
+    Route::get('/ferry/passenger-reports', [FerryOperatorReportController::class, 'index'])->name('ferry-reports.index');
+    Route::get('/ferry/passenger-reports/export', [FerryOperatorReportController::class, 'export'])->name('ferry-reports.export');
 });
 
 Route::get('/{page_name}', [PagesController::class, 'show'])->name('custom_page'); // Generic route AFTER all specific routes
-
-
 
 // ...

--- a/application/tests/Feature/ExampleTest.php
+++ b/application/tests/Feature/ExampleTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * A basic test example.
      */

--- a/application/tests/Feature/OperatorPanelScopingTest.php
+++ b/application/tests/Feature/OperatorPanelScopingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Ferry\Resources\FerryBookingResource;
+use App\Filament\Ferry\Resources\FerryResource;
+use App\Filament\Game\Resources\GameBookingResource;
+use App\Filament\Game\Resources\GameResource;
+use App\Filament\Ride\Resources\RideBookingResource;
+use App\Models\Ferry;
+use App\Models\FerryBooking;
+use App\Models\Game;
+use App\Models\GameBooking;
+use App\Models\Island;
+use App\Models\Ride;
+use App\Models\RideBooking;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OperatorPanelScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ferry_operator_resource_query_only_returns_owned_ferries(): void
+    {
+        $operator = User::factory()->create();
+        $otherOperator = User::factory()->create();
+        $island = $this->createIsland();
+
+        $ownedFerry = Ferry::create([
+            'user_id' => $operator->id,
+            'name' => 'Owned Ferry',
+            'price' => 50,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        Ferry::create([
+            'user_id' => $otherOperator->id,
+            'name' => 'Other Ferry',
+            'price' => 60,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        $this->actingAs($operator);
+
+        $visibleIds = FerryResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertSame([$ownedFerry->id], $visibleIds);
+    }
+
+    public function test_ferry_operator_booking_query_only_returns_bookings_for_owned_ferries(): void
+    {
+        $operator = User::factory()->create();
+        $otherOperator = User::factory()->create();
+        $customer = User::factory()->create();
+        $island = $this->createIsland();
+
+        $ownedFerry = Ferry::create([
+            'user_id' => $operator->id,
+            'name' => 'Owned Ferry',
+            'price' => 50,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        $otherFerry = Ferry::create([
+            'user_id' => $otherOperator->id,
+            'name' => 'Other Ferry',
+            'price' => 60,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        $ownedBooking = FerryBooking::create([
+            'user_id' => $customer->id,
+            'ferry_id' => $ownedFerry->id,
+            'booking_time' => now()->addDay()->setTime(10, 0),
+            'quantity' => 2,
+            'total_price' => 100,
+            'status' => 'confirmed',
+        ]);
+
+        FerryBooking::create([
+            'user_id' => $customer->id,
+            'ferry_id' => $otherFerry->id,
+            'booking_time' => now()->addDay()->setTime(11, 0),
+            'quantity' => 1,
+            'total_price' => 60,
+            'status' => 'confirmed',
+        ]);
+
+        $this->actingAs($operator);
+
+        $visibleIds = FerryBookingResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertSame([$ownedBooking->id], $visibleIds);
+    }
+
+    public function test_game_operator_resource_query_only_returns_owned_games(): void
+    {
+        $operator = User::factory()->create();
+        $otherOperator = User::factory()->create();
+        $island = $this->createIsland();
+
+        $ownedGame = Game::create([
+            'user_id' => $operator->id,
+            'island_id' => $island->id,
+            'name' => 'Owned Game',
+            'price' => 30,
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+            'max_capacity' => 40,
+            'max_booking_quantity' => 4,
+        ]);
+
+        Game::create([
+            'user_id' => $otherOperator->id,
+            'island_id' => $island->id,
+            'name' => 'Other Game',
+            'price' => 35,
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+            'max_capacity' => 40,
+            'max_booking_quantity' => 4,
+        ]);
+
+        $this->actingAs($operator);
+
+        $visibleIds = GameResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertSame([$ownedGame->id], $visibleIds);
+    }
+
+    public function test_game_operator_booking_query_only_returns_bookings_for_owned_games(): void
+    {
+        $operator = User::factory()->create();
+        $otherOperator = User::factory()->create();
+        $customer = User::factory()->create();
+        $island = $this->createIsland();
+
+        $ownedGame = Game::create([
+            'user_id' => $operator->id,
+            'island_id' => $island->id,
+            'name' => 'Owned Game',
+            'price' => 30,
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+            'max_capacity' => 40,
+            'max_booking_quantity' => 4,
+        ]);
+
+        $otherGame = Game::create([
+            'user_id' => $otherOperator->id,
+            'island_id' => $island->id,
+            'name' => 'Other Game',
+            'price' => 35,
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+            'max_capacity' => 40,
+            'max_booking_quantity' => 4,
+        ]);
+
+        $ownedBooking = GameBooking::create([
+            'user_id' => $customer->id,
+            'game_id' => $ownedGame->id,
+            'booking_time' => now()->addDay()->setTime(9, 0),
+            'quantity' => 2,
+            'total_price' => 60,
+            'status' => 'confirmed',
+        ]);
+
+        GameBooking::create([
+            'user_id' => $customer->id,
+            'game_id' => $otherGame->id,
+            'booking_time' => now()->addDay()->setTime(17, 0),
+            'quantity' => 1,
+            'total_price' => 35,
+            'status' => 'confirmed',
+        ]);
+
+        $this->actingAs($operator);
+
+        $visibleIds = GameBookingResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertSame([$ownedBooking->id], $visibleIds);
+    }
+
+    public function test_ride_operator_booking_query_only_returns_bookings_for_owned_rides(): void
+    {
+        $operator = User::factory()->create();
+        $otherOperator = User::factory()->create();
+        $customer = User::factory()->create();
+        $island = $this->createIsland();
+
+        $ownedRide = Ride::create([
+            'user_id' => $operator->id,
+            'island_id' => $island->id,
+            'name' => 'Owned Ride',
+            'price' => 45,
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+            'max_capacity' => 60,
+            'max_booking_quantity' => 4,
+        ]);
+
+        $otherRide = Ride::create([
+            'user_id' => $otherOperator->id,
+            'island_id' => $island->id,
+            'name' => 'Other Ride',
+            'price' => 55,
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+            'max_capacity' => 60,
+            'max_booking_quantity' => 4,
+        ]);
+
+        $ownedBooking = RideBooking::create([
+            'user_id' => $customer->id,
+            'ride_id' => $ownedRide->id,
+            'booking_time' => now()->addDay()->setTime(9, 0),
+            'quantity' => 1,
+            'total_price' => 45,
+            'status' => 'confirmed',
+        ]);
+
+        RideBooking::create([
+            'user_id' => $customer->id,
+            'ride_id' => $otherRide->id,
+            'booking_time' => now()->addDay()->setTime(17, 0),
+            'quantity' => 1,
+            'total_price' => 55,
+            'status' => 'confirmed',
+        ]);
+
+        $this->actingAs($operator);
+
+        $visibleIds = RideBookingResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertSame([$ownedBooking->id], $visibleIds);
+    }
+
+    private function createIsland(): Island
+    {
+        return Island::create([
+            'name' => 'Horror Island',
+            'type' => 'Horror-Island',
+            'description' => 'Main island',
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+        ]);
+    }
+}

--- a/application/tests/Feature/PromotionsAndFerryOperationsTest.php
+++ b/application/tests/Feature/PromotionsAndFerryOperationsTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Ferry;
+use App\Models\FerryBooking;
+use App\Models\Island;
+use App\Models\Promotion;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PromotionsAndFerryOperationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+        $this->app->instance('dompdf.wrapper', new class
+        {
+            public function loadView(string $view, array $data = []): self
+            {
+                return $this;
+            }
+
+            public function output(): string
+            {
+                return 'pdf-content';
+            }
+        });
+    }
+
+    public function test_homepage_only_renders_active_promotions(): void
+    {
+        Promotion::create([
+            'title' => 'Moonlit Escape',
+            'description' => 'A limited offer for haunted harbor stays.',
+            'discount_percentage' => 15,
+            'cta_label' => 'Reserve now',
+            'cta_url' => '/hotels',
+            'is_active' => true,
+            'starts_at' => now()->subDay(),
+            'ends_at' => now()->addDay(),
+        ]);
+
+        Promotion::create([
+            'title' => 'Expired Offer',
+            'description' => 'This should not be visible.',
+            'is_active' => true,
+            'starts_at' => now()->subDays(4),
+            'ends_at' => now()->subDay(),
+        ]);
+
+        Promotion::create([
+            'title' => 'Draft Offer',
+            'description' => 'This should stay hidden.',
+            'is_active' => false,
+        ]);
+
+        $response = $this->get(route('home'));
+
+        $response->assertOk();
+        $response->assertSeeText('Moonlit Escape');
+        $response->assertDontSeeText('Expired Offer');
+        $response->assertDontSeeText('Draft Offer');
+    }
+
+    public function test_ferry_booking_generates_a_separate_ferry_pass_and_download_endpoint(): void
+    {
+        $user = User::factory()->create();
+        $owner = User::factory()->create();
+        $island = $this->createIsland('Picnic Island', 'Picnic-Island');
+
+        $ferry = Ferry::create([
+            'user_id' => $owner->id,
+            'name' => 'Picnic Shuttle',
+            'price' => 35,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        $response = $this->actingAs($user)->post(route('bookings.ferries.store', $ferry), [
+            'booking_time' => now()->addDay()->setTime(10, 0)->format('Y-m-d H:i:s'),
+            'quantity' => 2,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        $booking = FerryBooking::first();
+
+        $this->assertNotNull($booking);
+        $this->assertNotNull($booking->pass_number);
+        $this->assertNotNull($booking->pass_path);
+        Storage::disk('local')->assertExists($booking->pass_path);
+
+        $download = $this->actingAs($user)->get(route('bookings.ferries.pass', $booking));
+
+        $download->assertOk();
+    }
+
+    public function test_ferry_manager_passenger_report_only_shows_owned_manifest_rows(): void
+    {
+        $operator = User::factory()->create();
+        $otherOperator = User::factory()->create();
+        $customer = User::factory()->create(['name' => 'Visible Passenger']);
+        $otherCustomer = User::factory()->create(['name' => 'Hidden Passenger']);
+        $island = $this->createIsland('Horror Island', 'Horror-Island');
+
+        Role::findOrCreate('ferry_manager', 'web');
+        $operator->assignRole('ferry_manager');
+
+        $ownedFerry = Ferry::create([
+            'user_id' => $operator->id,
+            'name' => 'Operator Ferry',
+            'price' => 40,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        $otherFerry = Ferry::create([
+            'user_id' => $otherOperator->id,
+            'name' => 'Other Ferry',
+            'price' => 45,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        FerryBooking::create([
+            'user_id' => $customer->id,
+            'ferry_id' => $ownedFerry->id,
+            'booking_time' => now()->setTime(10, 0),
+            'quantity' => 2,
+            'total_price' => 80,
+            'status' => 'confirmed',
+            'pass_number' => 'PASS-VISIBLE',
+            'pass_path' => 'ferry-passes/PASS-VISIBLE.pdf',
+        ]);
+
+        FerryBooking::create([
+            'user_id' => $otherCustomer->id,
+            'ferry_id' => $otherFerry->id,
+            'booking_time' => now()->setTime(10, 0),
+            'quantity' => 1,
+            'total_price' => 45,
+            'status' => 'confirmed',
+            'pass_number' => 'PASS-HIDDEN',
+            'pass_path' => 'ferry-passes/PASS-HIDDEN.pdf',
+        ]);
+
+        $response = $this->actingAs($operator)->get(route('ferry-reports.index', [
+            'date' => now()->toDateString(),
+        ]));
+
+        $response->assertOk();
+        $response->assertSeeText('Visible Passenger');
+        $response->assertDontSeeText('Hidden Passenger');
+        $response->assertSeeText('Operator Ferry');
+        $response->assertDontSeeText('Other Ferry');
+    }
+
+    public function test_ferry_manager_can_export_owned_manifest_as_csv(): void
+    {
+        $operator = User::factory()->create();
+        $customer = User::factory()->create(['name' => 'CSV Passenger', 'email' => 'csv@example.com']);
+        $island = $this->createIsland('Picnic Island', 'Picnic-Island');
+
+        Role::findOrCreate('ferry_manager', 'web');
+        $operator->assignRole('ferry_manager');
+
+        $ferry = Ferry::create([
+            'user_id' => $operator->id,
+            'name' => 'CSV Ferry',
+            'price' => 32,
+            'max_capacity' => 100,
+            'max_booking_quantity' => 5,
+            'island_id' => $island->id,
+        ]);
+
+        FerryBooking::create([
+            'user_id' => $customer->id,
+            'ferry_id' => $ferry->id,
+            'booking_time' => now()->setTime(11, 0),
+            'quantity' => 3,
+            'total_price' => 96,
+            'status' => 'confirmed',
+            'pass_number' => 'PASS-CSV',
+            'pass_path' => 'ferry-passes/PASS-CSV.pdf',
+        ]);
+
+        $response = $this->actingAs($operator)->get(route('ferry-reports.export', [
+            'date' => now()->toDateString(),
+        ]));
+
+        $response->assertOk();
+        $content = $response->streamedContent();
+
+        $this->assertStringContainsString('CSV Passenger', $content);
+        $this->assertStringContainsString('CSV Ferry', $content);
+        $this->assertStringContainsString('PASS-CSV', $content);
+    }
+
+    private function createIsland(string $name, string $type): Island
+    {
+        return Island::create([
+            'name' => $name,
+            'type' => $type,
+            'description' => $name.' description',
+            'latitude' => 4.2,
+            'longitude' => 73.4,
+            'images' => [],
+        ]);
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,7 @@
 # Architecture
 
 ## Overview
-This is a Laravel 11 monolith for a theme park booking site with a Filament
-admin panel. The customer-facing site supports browsing and booking hotels,
-ferry tickets, rides, games, and beach events, plus a contact form, CMS pages,
-and a customer booking portal. Admins manage catalog data and bookings via
-Filament resources.
+Horror Bark is a Laravel 11 monolith with Blade/Vite on the public site and Filament v3 for admin/operator panels. The same codebase serves customer browsing/booking, operator workflows, PDF document generation, and marketing/content management.
 
 ## High-Level Diagram
 ```
@@ -16,85 +12,77 @@ Filament resources.
                        v
            +-----------------------+
            |     Laravel App       |
-           |  routes + middleware  |
+           | routes + middleware   |
            +-----------+-----------+
                        |
-        +--------------+-------------------+
-        |                                  |
-        v                                  v
-+-------------------+            +-----------------------+
-| MVC Controllers   |            |  Filament Admin       |
-| (web + bookings)  |            |  /admin resources     |
-+---------+---------+            +-----------+-----------+
-          |                                  |
-          v                                  v
-+-------------------+            +-----------------------+
-| Blade Views +     |            |  Eloquent Models      |
-| Vite Assets        |            |  + Policies           |
-+---------+---------+            +-----------+-----------+
-          |                                  |
-          +---------------+------------------+
-                          v
-                  +---------------+
-                  |   Database    |
-                  +---------------+
-                          |
-                          v
-                  +---------------+
-                  |  Storage/FS   |
-                  +---------------+
+        +--------------+------------------------------+
+        |                                             |
+        v                                             v
++------------------------+                +---------------------------+
+| Public MVC Controllers |                | Filament Panels           |
+| catalogs + bookings    |                | admin + operator portals  |
++-----------+------------+                +-------------+-------------+
+            |                                             |
+            v                                             v
++------------------------+                +---------------------------+
+| Blade Views + Vite     |                | Eloquent Models + Queries |
+| homepage + portal      |                | scoped by role/ownership  |
++-----------+------------+                +-------------+-------------+
+            +-----------------------------+-------------+
+                                          v
+                                  +---------------+
+                                  |   Database    |
+                                  +-------+-------+
+                                          |
+                                          v
+                                  +---------------+
+                                  | Storage / PDF |
+                                  +---------------+
 ```
 
-## Booking Flow (Customer)
-```
-[Browse] -> [Select item] -> [Create Booking] -> [Invoice] -> [Portal]
-   |            |                  |               |          |
-   |            |                  |               |          +-- View/cancel booking
-   |            |                  |               +------------- Download invoice
-   |            |                  +----------------------------- Booking record
-   +------------+----------------------------------------------- Public catalog
-```
-
-## Key Modules
-- Web routes: `application/routes/web.php`
-- Controllers: `application/app/Http/Controllers/`
-- Booking controllers: `application/app/Http/Controllers/Bookings/`
-- Models: `application/app/Models/`
-- Filament resources: `application/app/Filament/Resources/`
-- Views/assets: `application/resources/`
-
-## Core Domain Entities
+## Core Domains
 - Hotels, Rooms, HotelBookings
-- Ferries, FerrySlots, FerryBookings
+- Ferries, FerrySlots, FerryBookings, Ferry Passes
 - Rides, RideBookings
 - Games, GameBookings
 - BeachEvents, BeachEventBookings
-- Islands
-- Pages (CMS)
-- Contacts (contact form)
 - Invoices
-- Users
-
-## Admin (Filament)
-Admins use Filament resources to manage:
-- Catalog data (hotels, rooms, ferries, slots, rides, games, events, islands)
-- CMS pages
-- Users
+- Promotions
+- Islands
+- Pages
 - Contacts
-- Bookings and invoices
+- Users and role-based panel access
 
-## Data & State
+## Public Flow
 ```
-Catalog (hotels/ferries/rides/games/events)
-        |
-        v
-Bookings (per user)
-        |
-        v
-Invoices + Downloads
+[Browse] -> [Select item] -> [Create booking] -> [Invoice / Ferry Pass] -> [Portal]
+     |             |                |                    |                |
+     |             |                |                    |                +-- View / cancel
+     |             |                |                    +------------------- Download documents
+     |             |                +---------------------------------------- Persist booking
+     +-------------+--------------------------------------------------------- Catalog + marketing
 ```
 
-## Runtime/Deployment
-- Local dev: `composer dev` in `application/`
-- Docker stack: `docker-compose.yml` with PHP-FPM + Nginx + MySQL
-- Public files via `storage:link`
+## Panels
+- `admin`: full management, dashboards, promotions, content, users, bookings
+- `hotel`: hotel inventory and hotel booking operations
+- `ferry`: ferry inventory, ferry booking operations, passenger reports
+- `ride`: ride inventory and ride booking operations
+- `game`: game inventory and game booking operations
+- `user`: customer-facing booking widgets and summaries
+
+## Important Runtime Rules
+- Ferry bookings require a valid overlapping hotel stay only when the destination is Horror Island.
+- Ride and game bookings require a valid overlapping hotel stay on Horror Island.
+- Beach events default to Picnic Island access rules unless explicitly linked otherwise.
+- Ferry operators, game operators, ride operators, and hotel operators are scoped to their own records in their panels.
+
+## Documents and Reporting
+- Invoices are generated as PDFs for all booking types.
+- Ferry bookings generate a separate ferry pass PDF.
+- Ferry operators can view passenger manifests and export CSV trip reports.
+
+## Deployment
+- Local dev via `composer dev`
+- Docker via `docker-compose.yml`
+- CI via GitHub Actions for tests, Pint, and frontend build

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,15 +1,16 @@
 # Developer Guide
 
-## Tech Stack
-- Laravel 11 (PHP 8.2+)
-- Filament v3 (admin panels)
-- Blade + Vite (frontend assets)
-- MySQL (Docker default) or SQLite (local default in `.env.example`)
-- Nginx + PHP-FPM (Docker)
+## Stack
+- Laravel 11 / PHP 8.2+
+- Filament v3
+- Blade + Tailwind + Alpine + Vite
+- SQLite by default locally, MySQL in Docker
+- DomPDF for invoices and ferry passes
+- Spatie Permission + Filament Shield
 
-## Local Setup (Non-Docker)
+## Local Setup
 Run from `application/`:
-```
+```bash
 composer install
 npm install
 cp .env.example .env
@@ -18,14 +19,9 @@ php artisan migrate:fresh --seed
 php artisan storage:link
 composer dev
 ```
-App: `http://127.0.0.1:8000`  
-Admin: `http://127.0.0.1:8000/admin`
-
-Admin login (seeded):
-- `test@admin.com` / `test@admin.com`
 
 ## Docker Setup
-```
+```bash
 docker-compose up -d
 docker-compose exec php bash
 cd /var/www/html
@@ -35,65 +31,34 @@ php artisan migrate:fresh --seed
 php artisan storage:link
 php artisan vendor:publish --tag=maps-views
 ```
-App: `http://localhost:8080`  
-Admin: `http://localhost:8080/admin`
 
-## Key Workflows
-- Dev server + queue + logs + Vite: `composer dev`
-- Vite only: `npm run dev`
-- Build assets: `npm run build`
-- Tests: `php artisan test` or `vendor/bin/phpunit`
-- Format PHP: `php artisan pint`
+## Seeded Admin
+- `test@admin.com`
+- password `test@admin.com`
 
-## Queue (DB Driver)
-Use the database queue to avoid extra infrastructure.
-1) Create the jobs table:
-```
-php artisan queue:table
-php artisan migrate
-```
-2) Set `.env`:
-```
-QUEUE_CONNECTION=database
-```
-3) Run a worker:
-```
-php artisan queue:work
-```
+## Common Commands
+- `composer dev`
+- `php artisan test`
+- `./vendor/bin/pint --test`
+- `npm run build`
 
 ## App Map
 - Routes: `application/routes/web.php`
 - Controllers: `application/app/Http/Controllers/`
 - Booking controllers: `application/app/Http/Controllers/Bookings/`
+- Services: `application/app/Services/`
+- Filament resources/panels: `application/app/Filament/`
 - Models: `application/app/Models/`
-- Filament resources: `application/app/Filament/Resources/`
 - Views/assets: `application/resources/`
-- Migrations/seeders: `application/database/`
+- Tests: `application/tests/`
 
-## Core Features
-- Public catalog pages: hotels, ferries, theme park rides, games, beach events
-- Customer auth + booking portal
-- Booking creation and cancellations
-- Invoices (view + download)
-- Contact form
-- CMS pages
-- Filament admin resources for all core domains
+## Current Implementation Notes
+- Promotions are admin-managed through `PromotionResource` and rendered on the public homepage.
+- Ferry bookings issue both an invoice and a ferry pass.
+- Ferry passenger reports live on `/ferry/passenger-reports` and support CSV export.
+- Island-aware booking enforcement is implemented in `IslandAccessService`.
+- Operator resources are scoped by ownership rather than showing global inventory.
 
-## Data Model (High Level)
-- `Hotel` -> `Room` -> `HotelBooking`
-- `Ferry` -> `FerryBooking` (with slots)
-- `Ride` -> `RideBooking`
-- `Game` -> `GameBooking`
-- `BeachEvent` -> `BeachEventBooking`
-- `Invoice` tied to bookings
-- `Page` for CMS content
-- `Contact` for contact form submissions
-
-## Admin (Filament)
-Admins manage catalog data, bookings, invoices, pages, users, and contacts.
-See `application/app/Filament/Resources/` for per-domain configuration.
-
-## Notes
-- `composer dev` starts a queue listener, but the app currently has few or no
-  custom queued jobs defined. If adding mail/async processing, consider jobs.
-- `.env.example` defaults to SQLite; switch to MySQL for parity with Docker.
+## Verification Notes
+- The repo now includes a GitHub Actions workflow at `.github/workflows/ci.yml`.
+- Local verification still requires installing Composer and npm dependencies because vendor/node modules are not committed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # Docs
 
-- `docs/ARCHITECTURE.md`: System overview and ASCII diagrams.
-- `docs/DEVELOPER.md`: Developer setup, workflows, and app map.
-- `docs/TODO.md`: Proposed improvements backlog.
-- `docs/BOOKING_FILTERS.md`: Query params for catalog/portal filter UX.
-- `docs/ISLAND_ACCESS_RULES.md`: Horror/Picnic island booking access matrix.
+- `docs/ARCHITECTURE.md`: current system overview and runtime shape
+- `docs/DEVELOPER.md`: setup, workflows, and panel/app map
+- `docs/REQUIREMENTS_GAP.md`: verified status review of resolved vs remaining gaps
+- `docs/TODO.md`: forward-looking backlog after the latest recovery work
+- `docs/BOOKING_FILTERS.md`: customer-facing filter/query behavior
+- `docs/ISLAND_ACCESS_RULES.md`: enforced Horror/Picnic island access rules

--- a/docs/REQUIREMENTS_GAP.md
+++ b/docs/REQUIREMENTS_GAP.md
@@ -1,167 +1,40 @@
-# Requirements Gap Analysis
+# Requirements Status Review
 
-Analysis of Horror-Bark implementation against UWE assignment requirements.
+Verified against the current repository state on 2026-03-31.
 
-**Date:** 2026-02-08
+## Important Context
+- Earlier versions of this document overstated several gaps.
+- `uwe-course.md` is a module description, not a precise feature checklist for this repo.
+- This review is based on the implemented code, tests, and docs currently in the worktree.
 
----
+## Resolved Since Earlier Gap Analysis
+- Ferry bookings now enforce hotel-stay requirements for Horror Island access.
+- Ride and game bookings also enforce island-aware hotel-stay rules.
+- Admin/operator dashboards and chart widgets exist across panels.
+- Ferry pass generation is implemented as a separate document flow from invoices.
+- Ferry passenger/trip reporting is implemented with CSV export.
+- Promotional content management is implemented through a dedicated Filament resource and homepage rendering.
+- Operator data isolation has been tightened so ferry/game/ride operators are scoped to their own records and related bookings.
 
-## Critical Missing Features
+## Implemented Core Capabilities
+- User registration and authentication
+- Hotel booking with room availability checks
+- Ferry booking with island-aware validation
+- Ride, game, and beach event booking
+- Invoice generation and downloads
+- Ferry pass generation and downloads
+- Customer portal with booking history and receipts
+- Multi-panel Filament admin/operator structure
+- Role-based panel access
+- Public catalog filters
+- Homepage promotions and interactive map content
 
-### 1. Ferry Booking Requires Valid Hotel Booking
+## Remaining Gaps
+- No payment gateway or payment-state workflow
+- No outbound booking emails
+- Limited export/report coverage outside ferry operations
+- No audit-log trail for sensitive back-office actions
+- No production deployment/backup documentation yet
 
-**Priority:** HIGH
-**Assignment Requirement:** "Purchase ferry tickets (only if a valid hotel booking exists)"
-
-**Current State:** No validation - users can book ferries without hotel bookings. Homepage shows a notice but it's not enforced.
-
-**Implementation:**
-- Add validation in `FerryBookingController@store`
-- Check for active hotel booking: `HotelBooking::where('user_id', auth()->id())->where('status', '!=', 'canceled')->exists()`
-- Return error if no valid hotel booking exists
-- Update frontend to show clear messaging
-
-**Files to modify:**
-- `app/Http/Controllers/Bookings/FerryBookingController.php`
-- `resources/views/pages/ferrytickets.blade.php`
-
----
-
-### 2. Admin/Operator Analytics Dashboards
-
-**Priority:** HIGH
-**Assignment Requirement:** "View booking reports", "Track ticket sales", "Reports on ticket sales and visitors"
-
-**Current State:** Only customer-level booking dashboard exists. No admin or operator analytics.
-
-**Implementation:**
-- Create Filament dashboard widgets for each panel
-- Admin dashboard: total bookings, revenue, user counts, booking trends
-- Hotel panel: occupancy rates, room booking stats, revenue
-- Ferry panel: passenger counts, trip reports, capacity utilization
-- Ride/Game panels: booking counts, popular times, capacity usage
-
-**Files to create:**
-- `app/Filament/Widgets/StatsOverview.php`
-- `app/Filament/Widgets/BookingChart.php`
-- `app/Filament/Hotel/Widgets/HotelStats.php`
-- `app/Filament/Ferry/Widgets/FerryStats.php`
-
----
-
-### 3. Promotional Offers Management
-
-**Priority:** MEDIUM
-**Assignment Requirement:** "Manage promotional offers for hotel stays", "Manage advertisements and promotional content"
-
-**Current State:** Featured cards on homepage are hardcoded. No admin system to manage promotions.
-
-**Implementation:**
-- Create `Promotion` model with fields: title, description, discount_percentage, start_date, end_date, promotable_type, promotable_id (polymorphic)
-- Create migration for promotions table
-- Create Filament resource for admin to manage promotions
-- Update homepage to display active promotions from database
-- Allow hotel/ride/ferry operators to create promotions for their entities
-
-**Files to create:**
-- `app/Models/Promotion.php`
-- `database/migrations/xxxx_create_promotions_table.php`
-- `app/Filament/Resources/PromotionResource.php`
-
-**Files to modify:**
-- `app/Http/Controllers/HomeController.php`
-- `resources/views/pages/home.blade.php`
-
----
-
-### 4. Ferry Pass/Ticket Generation
-
-**Priority:** MEDIUM
-**Assignment Requirement:** "Provide customer with a ferry pass if valid hotel booking exist", "Ferry ticket issuance form"
-
-**Current State:** Only generic invoices are generated. No ferry-specific pass document.
-
-**Implementation:**
-- Create ferry pass PDF template with: pass number, passenger name, ferry details, booking time, QR code
-- Generate pass on successful ferry booking
-- Add pass download link in customer portal
-- Store pass_path in FerryBooking model
-
-**Files to create:**
-- `resources/views/ferry-passes/pdf.blade.php`
-- `app/Services/FerryPassService.php`
-
-**Files to modify:**
-- `app/Models/FerryBooking.php` (add pass_path field)
-- `database/migrations/xxxx_add_pass_path_to_ferry_bookings.php`
-- `app/Http/Controllers/Bookings/FerryBookingController.php`
-- `resources/views/pages/bookings/show.blade.php`
-
----
-
-### 5. Passenger List & Trip Reports
-
-**Priority:** MEDIUM
-**Assignment Requirement:** "Passenger list & trip reports" for ferry operators
-
-**Current State:** Ferry operators can see bookings but no aggregated passenger list or trip report view.
-
-**Implementation:**
-- Add "Passenger List" action to FerryResource in Ferry panel
-- Group bookings by ferry and booking_time
-- Show passenger counts per trip
-- Add export to PDF/CSV functionality
-
-**Files to create:**
-- `app/Filament/Ferry/Pages/PassengerList.php`
-- `resources/views/filament/ferry/passenger-list.blade.php`
-
----
-
-## Partially Implemented Features
-
-### 6. Promotional Banners on Homepage
-
-**Priority:** LOW
-**Current State:** Featured cards exist but are randomly selected, not admin-controlled.
-
-**Implementation:** Covered by task #3 (Promotional Offers Management)
-
----
-
-### 7. Customer Booking Reports Enhancement
-
-**Priority:** LOW
-**Current State:** Basic stats shown. Could add more filtering and export options.
-
-**Implementation:**
-- Add date range revenue breakdown
-- Add booking history export (PDF/CSV)
-- Add visual charts for booking trends
-
----
-
-## Implementation Order
-
-1. **Ferry Booking Validation** - Critical for assignment compliance
-2. **Admin Analytics Dashboards** - Required for all operator roles
-3. **Promotional Offers System** - Required for marketing features
-4. **Ferry Pass Generation** - Required for complete ferry workflow
-5. **Passenger Reports** - Required for ferry operators
-
----
-
-## Verified Implemented Features
-
-- User registration/login
-- Hotel booking with date selection
-- Room management with availability
-- Ferry schedule management
-- Theme park rides/games booking
-- Beach events booking
-- Interactive island map (Leaflet)
-- Invoice generation with PDF
-- Multi-panel admin system (6 panels)
-- Role-based access control
-- Booking cancellation
-- Customer booking portal
+## Recommendation
+Treat the repo as a coherent demo/handoff-ready MVP. The highest-value next work is operational hardening and payment/email workflows, not rebuilding the existing booking foundations.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,27 +1,19 @@
-# Improvements Backlog (Proposed)
+# Forward Backlog
 
-## Product/UX
-- [ ] Add search and filters for catalog pages (hotels, ferries, rides, games).
-- [ ] Add booking confirmation emails with calendar attachments.
-- [ ] Add payment status and gateway integration (stripe/paypal/etc.).
-- [ ] Improve customer portal with booking history and receipts list.
-- [ ] Refresh the public site UI (modern typography, updated layouts, mobile-first).
-- [ ] Update imagery and visual branding to reduce "dated" feel.
+## Product
+- [ ] Add payment status and gateway integration.
+- [ ] Send booking confirmation emails with document attachments.
+- [ ] Improve public-site visual polish and image curation.
+- [ ] Refine operator-side booking creation flows to better support walk-up/manual bookings.
 
-## Admin/Analytics
-- [ ] Add Filament stat dashboards (KPIs, revenue, bookings, cancellations).
-- [ ] Add trend charts for booking volume by product and date range.
+## Admin / Reporting
+- [ ] Expand exports beyond ferry CSV to other product types.
+- [ ] Add richer charts for revenue and attendance trends over longer periods.
 
-## Reliability/Operations
-- [ ] Add CI pipeline for tests and linting (PHPUnit + Pint + JS build).
-- [ ] Add structured logging and error reporting (Sentry/Logtail/etc.).
-- [ ] Add background jobs for emails/invoices using the DB queue (Redis optional).
-- [ ] Add backup/restore docs for database and storage.
+## Reliability
+- [ ] Add deployment notes for backup/restore of database and document storage.
+- [ ] Add production-grade error reporting and log aggregation.
 
 ## Security
-- [ ] Add role-based admin permissions and audit logs.
-
-## Engineering Quality
-- [ ] Add feature tests for booking flows and cancellations.
-- [ ] Add factories/seeders for realistic demo data.
-- [ ] Document API-like endpoints or internal services (if needed).
+- [ ] Add audit logs for sensitive admin/operator actions.
+- [ ] Review cross-panel permissions beyond the current ownership scoping pass.


### PR DESCRIPTION
## Summary
- refresh the project docs so they match the actual implementation state
- tighten operator scoping for ferry, game, and ride resources and add regression tests
- add admin-managed promotions plus homepage rendering
- add ferry pass generation/download and ferry passenger reporting with CSV export
- add CI for tests, targeted Pint checks, and frontend build

## Why
The repository had drifted between docs and code, operator isolation was inconsistent across panels, and several high-value demo features were still missing.

## Validation
- `php artisan test`
- `npm run build`
- targeted `./vendor/bin/pint --test` on the files changed in this recovery work

## Notes
- local verification surfaced PHP 8.5 deprecation noise from vendor/framework code, but the application tests pass
- repo-wide Pint still has legacy style debt outside this diff, so CI linting is scoped to the changed recovery files
